### PR TITLE
return hostname + FQDN when using -dc-ip

### DIFF
--- a/pywhisker.py
+++ b/pywhisker.py
@@ -40,7 +40,7 @@ def get_machine_name(args, domain):
             raise Exception('Error while anonymous logging into %s' % domain)
     else:
         s.logoff()
-    return s.getServerName()
+    return s.getServerName() + '.' + s.getServerDNSDomainName()
 
 
 def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):


### PR DESCRIPTION
Experiencing similar issues as outlined in #2 and #3 
In my case, using `-dc-ip` with `-k` was causing an error due to the DC hostname not containing the FQDN to match my kerberos ticket.
Followed Impacket implementations of similar `get_machine_name()` methods to return the hostname with the FQDN:
- [GetUserSPNs.py](https://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/GetUserSPNs.py#L132)
- [findDelegation.py](https://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/findDelegation.py#L108)
