### PR TITLE
Fix #10 and Minor Grammar/Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python3 PKINITtools/getnthash.py -key 894fde81fb7cf87963e4bda9e9e288536a0508a155
 ![](./.assets/add_pem_gettgtnthash.png)
 
 ## Spray new values
-pyWhisker can identify and exploit adding KeyCredentials to a target list based on any vulnerable write permissions.
+pyWhisker can chain multiple KeyCredentials additions, to a set of targets, i.e. spray (if the credentials used have the right permissions).
 
 ```shell
 python3 pywhisker.py -d "domain.local" -u "user1" -p "complexpassword" --target-list targetlist.txt --action "spray"

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python3 PKINITtools/getnthash.py -key 894fde81fb7cf87963e4bda9e9e288536a0508a155
 ![](./.assets/add_pem_gettgtnthash.png)
 
 ## Spray new values
-pyWhisker can spray the addition of KeyCredentials to a target list in order to identify any vulnerable write permissions.
+pyWhisker can identify and exploit adding KeyCredentials to a target list based on any vulnerable write permissions.
 
 ```shell
 python3 pywhisker.py -d "domain.local" -u "user1" -p "complexpassword" --target-list targetlist.txt --action "spray"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# PyWhisker
+# pyWhisker
 
 pyWhisker is a Python equivalent of the original [Whisker](https://github.com/eladshamir/Whisker) made by [Elad Shamir](https://twitter.com/elad_shamir) and written in C#. This tool allows users to manipulate the `msDS-KeyCredentialLink` attribute of a target user/computer to obtain full control over that object.
 It's based on [Impacket](https://github.com/SecureAuthCorp/impacket) and on a Python equivalent of [Michael Grafnetter's](https://twitter.com/MGrafnetter) [DSInternals](https://github.com/MichaelGrafnetter/DSInternals) called [PyDSInternals](https://github.com/p0dalirius/pydsinternals) made by [podalirius](https://twitter.com/podalirius_).
 This tool, along with [Dirk-jan's](https://twitter.com/_dirkjan) [PKINITtools](https://github.com/dirkjanm/PKINITtools) allow for a complete primitive exploitation on UNIX-based systems only.
 
-**Pre-requisites** for this attack are as follows
- 1. the target Domain Functional Level must be **Windows Server 2016** or above.
- 2. the target domain must have at least one Domain Controller running Windows Server 2016 or above.
- 3. the Domain Controller to use during the attack must have its own certificate and keys (this means either the organization must have AD CS, or a PKI, a CA or something alike).
- 4. the attacker must have control over an account able to write the `msDs-KeyCredentialLink` attribute of the target user or computer account.
+**Pre-requisites** for this attack are as follows:
+ 1. The target Domain Functional Level must be **Windows Server 2016** or above.
+ 2. The target domain must have at least one Domain Controller running Windows Server 2016 or above.
+ 3. The Domain Controller to use during the attack must have its own certificate and keys (this means either the organization must have AD CS, or a PKI, a CA or something alike).
+ 4. The attacker must have control over an account able to write the `msDs-KeyCredentialLink` attribute of the target user or computer account.
 
 Why some pre-reqs?
  - Pre-reqs 1 and 2 because the PKINIT features were introduced with Windows Server 2016.
@@ -16,23 +16,24 @@ Why some pre-reqs?
 
 A `KRB-ERROR (16) : KDC_ERR_PADATA_TYPE_NOSUPP` will be raised if pre-req 3 is not met.
 
-More information about this "Shadow Credentials" primitive
+More information about this "Shadow Credentials" primitive:
  - [Shadow Credentials: Abusing Key Trust Account Mapping for Takeover](https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab)
  - [The Hacker Recipes - ACEs abuse](https://www.thehacker.recipes/active-directory-domain-services/movement/access-control-entries)
  - [The Hacker Recipes - Shadow Credentials](https://www.thehacker.recipes/active-directory-domain-services/movement/access-control-entries/shadow-credentials)
 
 # Usage
 
-pyWhisker can be used to operate various actions on the msDs-KeyCredentialLink attribute of a target
+pyWhisker can be used to operate various actions on the msDs-KeyCredentialLink attribute of a target:
 - [list](https://github.com/ShutdownRepo/pywhisker#list-and-get-info): list all current KeyCredentials ID and creation time
-- [info](https://github.com/ShutdownRepo/pywhisker#list-and-get-info): print all info contained in a KeyCredential structure
 - [add](https://github.com/ShutdownRepo/pywhisker#add-new-values): add a new KeyCredential to the `msDs-KeyCredentialLink`
+- [spray](https://github.com/ShutdownRepo/pywhisker#spray-new-values): spray adding a new KeyCredential to the `msDs-KeyCredentialLink`
 - [remove](https://github.com/ShutdownRepo/pywhisker#clear-and-remove): remove a KeyCredential from the `msDs-KeyCredentialLink`
 - [clear](https://github.com/ShutdownRepo/pywhisker#clear-and-remove): remove all KeyCredentials from the `msDs-KeyCredentialLink`
+- [info](https://github.com/ShutdownRepo/pywhisker#list-and-get-info): print all info contained in a KeyCredential structure
 - [export](https://github.com/ShutdownRepo/pywhisker#import-and-export): export all KeyCredentials from the `msDs-KeyCredentialLink` in JSON
 - [import](https://github.com/ShutdownRepo/pywhisker#import-and-export): overwrite the `msDs-KeyCredentialLink` with KeyCredentials from a JSON file
 
-pyWhisker supports the following authentications
+pyWhisker supports the following authentications:
  - (NTLM) Cleartext password
  - (NTLM) [Pass-the-hash](https://www.thehacker.recipes/active-directory-domain-services/movement/lm-and-ntlm/pass-the-hash)
  - (Kerberos) Cleartext password
@@ -42,7 +43,7 @@ pyWhisker supports the following authentications
 Among other things, pyWhisker supports multi-level verbosity, just append `-v`, `-vv`, ... to the command :)
 
 ```
-usage: pywhisker.py [-h] -t TARGET_SAMNAME [-a [{list,add,remove,clear,info,export,import}]] [--use-ldaps] [-v] [-q] [--dc-ip ip address] [-d DOMAIN] [-u USER]
+usage: pywhisker.py [-h] [-t TARGET_SAMNAME | -tl TARGET_SAMNAME_LIST ] [-a [{list,add,spray,remove,clear,info,export,import}]] [--use-ldaps] [-v] [-q] [--dc-ip ip address] [-d DOMAIN] [-u USER]
                     [--no-pass | -p PASSWORD | -H [LMHASH:]NTHASH | --aes-key hex key] [-k] [-P PFX_PASSWORD] [-f FILENAME] [-e {PEM, PFX}] [-D DEVICE_ID]
 
 Python (re)setter for property msDS-KeyCredentialLink for Shadow Credentials attacks.
@@ -51,7 +52,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -t TARGET_SAMNAME, --target TARGET_SAMNAME
                         Target account
-  -a [{list,add,remove,clear,info,export,import}], --action [{list,add,remove,clear,info,export,import}]
+  -tl TARGET_SAMNAME_LIST, --target-list TARGET_SAMNAME_LIST
+						Path to a file with target accounts names (one per line)
+  -a [{list,add,spray,remove,clear,info,export,import}], --action [{list,add,spray,remove,clear,info,export,import}]
                         Action to operate on msDS-KeyCredentialLink
   --use-ldaps           Use LDAPS instead of LDAP
   -v, --verbose         verbosity level (-v for verbose, -vv for debug)
@@ -85,11 +88,11 @@ arguments when setting -action to remove:
                         device ID of the KeyCredentialLink to remove when setting -action to remove
 ```
 
-Below are examples and screenshots of what PyWhisker can do.
+Below are examples and screenshots of what pyWhisker can do.
 
 ## List and get info
 
-PyWhisker has the ability to list existing KeyCredentials. In addition to that, it can unfold the whole structure to show every piece of information that object contains (including the RSA public key parameters).
+pyWhisker has the ability to list existing KeyCredentials. In addition to that, it can unfold the whole structure to show every piece of information that object contains (including the RSA public key parameters).
 
 ```shell
 python3 pywhisker.py -d "domain.local" -u "user1" -p "complexpassword" --target "user2" --action "list"
@@ -116,8 +119,7 @@ python3 pywhisker.py -d "domain.local" -u "user1" -p "complexpassword" --target 
 
 ## Add new values
 
-pyWhisker has the ability to generate RSA keys, a X509 certificate, a KeyCredential structure, and to write the necessary information as new values of the `msDs-KeyCredentialLink` attribute.
-The certificate can be exported in a PFX format (#PKCS12, certificate + private key protected with a password) or in a PEM format (PEM certificate, PEM private key, no password needed).
+pyWhisker has the ability to generate RSA keys, a X509 certificate, a KeyCredential structure, and to write the necessary information as new values of the `msDs-KeyCredentialLink` attribute. The certificate can be exported in a PFX format (#PKCS12, certificate + private key protected with a password) or in a PEM format (PEM certificate, PEM private key, no password needed).
 
 ### Example with the PFX format
 
@@ -153,8 +155,14 @@ python3 PKINITtools/getnthash.py -key 894fde81fb7cf87963e4bda9e9e288536a0508a155
 
 ![](./.assets/add_pem_gettgtnthash.png)
 
+## Spray new values
+pyWhisker can spray the addition of KeyCredentials to a target list in order to identify any vulnerable write permissions.
 
-### Import and Export
+```shell
+python3 pywhisker.py -d "domain.local" -u "user1" -p "complexpassword" --target-list targetlist.txt --action "spray"
+```
+
+## Import and export
 
 KeyCredentials stored in the `msDs-KeyCredentialLink` attribute can be parsed, structured and saved as JSON.
 
@@ -164,16 +172,15 @@ The JSON export can then be used to restore the `msDs-KeyCredentialLink` attribu
 
 ![](./.assets/import.png)
 
-
 # Relayed authentication
 
-[A Pull Request](https://github.com/SecureAuthCorp/impacket/pull/1132) is currently awaiting approval to include pywhisker's "adding" feature to ntlmrelayx.
+[A Pull Request](https://github.com/fortra/impacket/pull/1249) was merged into ntlmrelayx to include pyWhisker's "adding" feature.
 
 ![](./.assets/relay.png)
 
 # Useful knowledge
 
-User objects can't edit their own `msDS-KeyCredentialLink` attribute. **Computer objects can**. This means the following scenario could work: trigger an NTLM authentication from DC01, relay it to DC02, make pywhisker edit DC01's attribute to create a Kerberos PKINIT pre-authentication backdoor on it.
+User objects can't edit their own `msDS-KeyCredentialLink` attribute. However, **computer objects can**. This means the following scenario could work: trigger an NTLM authentication from DC01, relay it to DC02, make pyWhisker edit DC01's attribute to create a Kerberos PKINIT pre-authentication backdoor on it.
 
 ![](./.assets/user_cant_self_edit.png)  
 


### PR DESCRIPTION
Fix #10 and Minor Grammar/Formatting

I noticed the pyWhisker was capitalized differently in name throughout the README. I standardized it to pyWhisker. If you want it all lowercase, let me know and I can modify it.