### PR TITLE
Fix error when ccache is None

### DIFF
--- a/pywhisker.py
+++ b/pywhisker.py
@@ -136,7 +136,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
             # No cache present
             print(e)
             pass
-        else:
+        if ccache is not None:
             # retrieve domain information from CCache file if needed
             if domain == '':
                 domain = ccache.principal.realm['data'].decode('utf-8')


### PR DESCRIPTION
Hello,

I came across an issue when using the tool with kerberos authentication.
Here is the command I used:

```bash
python3 pywhisker.py -vv -d domain.intra -u "user" -p 'password' -t 'target' -a 'add' --use-ldaps -k
```

<img width="1438" alt="image" src="https://github.com/ShutdownRepo/pywhisker/assets/52674895/2fb689a0-21f8-4691-8a84-6370a05a9d09">

It seems that the `CCache.loadFile` function returns None if the `fileName` argument passed is None.

<img width="835" alt="image" src="https://github.com/ShutdownRepo/pywhisker/assets/52674895/b5a1283c-dfa3-47bc-a862-ab99f5b51d56">

see https://github.com/fortra/impacket/blob/master/impacket/krb5/ccache.py#L581

To avoid this error, I added a check on the `ccache` variable.