### PR TITLE
Fixed Logger and error checking

### DIFF
--- a/pywhisker/pywhisker.py
+++ b/pywhisker/pywhisker.py
@@ -175,7 +175,7 @@ def ldap3_kerberos_login(connection, target, user, password, logger, domain='', 
                     TGT = creds.toTGT()
                     logger.debug('Using TGT from cache')
                 else:
-                    logger.debug('No valid credentials found in cache')
+                    logger.debug(f'Principal {principal} not found in cache')
             else:
                 TGS = creds.toTGS(principal)
                 logger.debug('Using TGS from cache')


### PR DESCRIPTION
The `logger` object was at some points still not accessible, this should fix it. I also added some more error handling, as we encountered a keycredential which crashed before the `toDict()` function, this should be more general. Also when loading a ccache, if it fails the looked for principal is printed to the debug log.