### PR TITLE
Implement starttls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ optional arguments:
   -a [{list,add,spray,remove,clear,info,export,import}], --action [{list,add,spray,remove,clear,info,export,import}]
                         Action to operate on msDS-KeyCredentialLink
   --use-ldaps           Use LDAPS instead of LDAP
+  --use-starttls        Use STARTTLS for LDAP connection upgrade
   --use-schannel        Use LDAP Schannel (TLS) for certificate-based authentication
   -v, --verbose         verbosity level (-v for verbose, -vv for debug)
   -q, --quiet           show no information at all


### PR DESCRIPTION
Implementation of LDAP STARTTLS. Useful if LDAPS in unavailable while DC still requires signing/TLS

Get kerberos ticket:

```
getTGT.py test.local/administrator:$DAPW

export KRB5CCNAME=~/administrator.ccache
```

```
pywhisker  -t demomachine\$ -a list -u administrator -k --dc-ip 100.64.5.200 -d test.local
[!] automatic bind not successful - strongerAuthRequired
```

```
pywhisker  -t demomachine\$ -a list -u administrator -k --dc-ip 100.64.5.200 -d test.local --use-starttls
[*] Searching for the target account
[*] Target user found: CN=DEMOMACHINE,CN=Computers,DC=test,DC=local
[*] Listing devices for demomachine$
[*] DeviceID: fbf8fb45-7e50-c9a8-dd82-c65676d9c082 | Creation Time (UTC): 2025-10-03 12:32:57.648661
```