### PR TITLE
[bug] (post–Microsoft patch) Fix Shadow Credentials validated write requirements for computer accounts adding a certificate to themselves

### DIFF
--- a/pywhisker/pywhisker.py
+++ b/pywhisker/pywhisker.py
@@ -421,8 +421,7 @@ class ShadowCredentials(object):
         certificate = X509Certificate2(subject=self.target_samname, keySize=2048, notBefore=(-40*365), notAfter=(40*365))
         self.logger.info("Certificate generated")
         self.logger.info("Generating KeyCredential")
-        isComputerKey = self.target_samname.endswith('$') or 'CN=Computers,' in self.target_dn
-        keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=isComputerKey)
+        keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=True)
         self.logger.info("KeyCredential generated with DeviceID: %s" % keyCredential.DeviceId.toFormatD())
         if self.logger.verbosity == 2:
             keyCredential.fromDNWithBinary(keyCredential.toDNWithBinary()).show()
@@ -503,8 +502,7 @@ class ShadowCredentials(object):
             else:
                 self.target_dn = result[0]
             certificate = X509Certificate2(subject=samname, keySize=2048, notBefore=(-40*365), notAfter=(40*365))
-            isComputerKey = samname.endswith('$') or 'CN=Computers,' in self.target_dn
-            keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=isComputerKey)
+            keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=True)
             self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
             results = None
             for entry in self.ldap_session.response:

--- a/pywhisker/pywhisker.py
+++ b/pywhisker/pywhisker.py
@@ -421,7 +421,8 @@ class ShadowCredentials(object):
         certificate = X509Certificate2(subject=self.target_samname, keySize=2048, notBefore=(-40*365), notAfter=(40*365))
         self.logger.info("Certificate generated")
         self.logger.info("Generating KeyCredential")
-        keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime())
+        isComputerKey = self.target_samname.endswith('$') or 'CN=Computers,' in self.target_dn
+        keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=isComputerKey)
         self.logger.info("KeyCredential generated with DeviceID: %s" % keyCredential.DeviceId.toFormatD())
         if self.logger.verbosity == 2:
             keyCredential.fromDNWithBinary(keyCredential.toDNWithBinary()).show()
@@ -502,7 +503,8 @@ class ShadowCredentials(object):
             else:
                 self.target_dn = result[0]
             certificate = X509Certificate2(subject=samname, keySize=2048, notBefore=(-40*365), notAfter=(40*365))
-            keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime())
+            isComputerKey = samname.endswith('$') or 'CN=Computers,' in self.target_dn
+            keyCredential = KeyCredential.fromX509Certificate2(certificate=certificate, deviceId=Guid(), owner=self.target_dn, currentTime=DateTime(), isComputerKey=isComputerKey)
             self.ldap_session.search(self.target_dn, '(objectClass=*)', search_scope=ldap3.BASE, attributes=['SAMAccountName', 'objectSid', 'msDS-KeyCredentialLink'])
             results = None
             for entry in self.ldap_session.response:


### PR DESCRIPTION
Following the [Twitter thread by @Defte_](https://x.com/Defte_/status/2016524729981571264?s=20), Microsoft changed the validated write rules for the `msDS-KeyCredentialLink` attribute, which broke Shadow Credentials attacks.

This PR adds the correct `KeyCredential` format is used (CustomKeyInformation with `MFANotUsed` flag and no `LastLogonTime`).

**Dependency**: This change depends on [pydsinternals,](https://github.com/p0dalirius/pydsinternals/pull/15) which updates the `KeyCredential` blob format for Microsoft’s new validated write requirements. That PR must be merged before this one works correctly.


Before : 

<img width="1338" height="267" alt="1" src="https://github.com/user-attachments/assets/cc387c94-760a-4e2a-bb80-02e59f45d923" />

After : 

<img width="1266" height="371" alt="2" src="https://github.com/user-attachments/assets/7ad1367d-b044-4bcd-829c-4b93f8fa73ee" />
